### PR TITLE
Add Twist Message Subscription to drive  both motors.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,20 @@
 # odrive-ros2-node
+
 ROS2-Node for ODrive
 
 # Features
+
 - polls odrive velocity, motor_position, applied voltage, odrive temperature and applied torque
 - sets desired velocity
 - Uses Checksum when communicating with ODrive
 
 # Polling rate
+
 - node polls one value every 10ms
 - request priority sets priority in poll-list using modulo(0 - 99)
 
 ## Example
+
 - priority_bus_voltage = 1, priority_temperature = 2
 - output:
 - counter 0:
@@ -26,15 +30,14 @@ ROS2-Node for ODrive
 - ...
 
 # Topics
+
 - publishes:
 
-
-- - <std_msgs/Float32>"/odrive_bus_voltage"
-- - <std_msgs/Float32>"/odrive0_velocity"
-- - <std_msgs/Float32>"/odrive0_position"
-- - <std_msgs/Float32>"/odrive0_temperature"
-- - <std_msgs/Float32>"/odrive0_torque"
-
+* - <std_msgs/Float32>"/odrive_bus_voltage"
+* - <std_msgs/Float32>"/odrive0_velocity"
+* - <std_msgs/Float32>"/odrive0_position"
+* - <std_msgs/Float32>"/odrive0_temperature"
+* - <std_msgs/Float32>"/odrive0_torque"
 
 - - <std_msgs/Float32>"/odrive1_velocity"
 - - <std_msgs/Float32>"/odrive1_position"
@@ -43,16 +46,21 @@ ROS2-Node for ODrive
 - set priority to 0 to disable topic
 
 listens to:
+
 - <std_msgs/Float32>"/odrive0_set_velocity"
 - <std_msgs/Float32>"/odrive1_set_velocity"
+- <geometry_msgs/Twist>"/odrive_cmd_velocity"
 
 # Usage
+
 - ros2 run odrive_node odrive_node
 - set motor variable to 0(default), 1, or 2 to set both to active
 - set priority from 0 to 99
 - (set to defaults)
-- - ros2 run odrive_node odrive_node --ros-args --remap __ns:=/<your-namespace> -p port:='/dev/ttyS1' -p motor:=0 -p priority_position_velocity:=1  -p priority_bus_voltage:=2 -p priority_temperature:=3 -p priority_torque:=4
+- - ros2 run odrive_node odrive_node --ros-args --remap __ns:=/<your-namespace> -p port:='/dev/ttyS1' -p motor:=0 -p priority_position_velocity:=1 -p priority_bus_voltage:=2 -p priority_temperature:=3 -p priority_torque:=4
 
 # Dependencies
+
 - rclcpp
 - std_msgs
+- geometry_msgs

--- a/odrive_node/CMakeLists.txt
+++ b/odrive_node/CMakeLists.txt
@@ -19,9 +19,10 @@ endif()
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(std_msgs REQUIRED)
+find_package(geometry_msgs REQUIRED)
 
 add_executable(odrive_node src/odrive_node.cpp)
-ament_target_dependencies(odrive_node rclcpp std_msgs)
+ament_target_dependencies(odrive_node rclcpp std_msgs geometry_msgs)
 
 install(TARGETS
   odrive_node

--- a/odrive_node/package.xml
+++ b/odrive_node/package.xml
@@ -13,6 +13,8 @@
   <test_depend>ament_lint_common</test_depend>
   <depend>rclcpp</depend>
   <depend>std_msgs</depend>
+  <depend>geometry_msgs</depend>
+
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/odrive_node/src/ODrive.cpp
+++ b/odrive_node/src/ODrive.cpp
@@ -1,5 +1,5 @@
 #include "ODrive.hpp"
-
+using geometry_msgs::msg::Vector3;
 /*
 ODrive starts by opening UART connection
 */

--- a/odrive_node/src/odrive_node.cpp
+++ b/odrive_node/src/odrive_node.cpp
@@ -12,6 +12,8 @@ ODriveNode::ODriveNode() : Node("odrive_node")
   this->declare_parameter<int>("priority_bus_voltage", 2);
   this->declare_parameter<int>("priority_temperature", 3);
   this->declare_parameter<int>("priority_torque", 4);
+  this->declare_parameter<double>("wheel_dist", 3.14);
+  this->declare_parameter<double>("wheel_radius", 1);
 
   // node sets parameter, if given
   this->get_parameter("port", port);
@@ -20,6 +22,8 @@ ODriveNode::ODriveNode() : Node("odrive_node")
   this->get_parameter("priority_bus_voltage", priority_bus_voltage);
   this->get_parameter("priority_temperature", priority_temperature);
   this->get_parameter("priority_torque", priority_torque);
+  this->get_parameter("wheel_dist", wheel_dist);
+  this->get_parameter("wheel_radius", wheel_radius);
 
   odrive = new ODrive(port, this);
 
@@ -75,6 +79,11 @@ ODriveNode::ODriveNode() : Node("odrive_node")
   {
     subscription_velocity1 = this->create_subscription<std_msgs::msg::Float32>("odrive" + std::to_string(1) + "_set_velocity", 10, std::bind(&ODriveNode::velocity_callback1, this, std::placeholders::_1));
   }
+  if(motor == 2)
+  {
+    subscription_cmd_vel = this->create_subscription<geometry_msgs::msg::Twist>("odrive_cmd_velocity", 10, std::bind(&ODriveNode::cmd_velocity_callback, this, std::placeholders::_1));
+  }
+
 
 //set callback rate
   timer_ = this->create_wall_timer(10ms, std::bind(&ODriveNode::odrive_callback, this));
@@ -97,6 +106,19 @@ void ODriveNode::velocity_callback1(const std_msgs::msg::Float32::SharedPtr msg)
 {
   float velocity = msg->data;
   odrive->setVelocity(1, velocity);
+}
+// send velocity on both motors from Twist Message
+void ODriveNode::cmd_velocity_callback(const geometry_msgs::msg::Twist::SharedPtr msg)
+{
+  Vector3 angular = msg->angular;
+  Vector3 linear = msg->linear;
+  double vel = linear.x;
+  double omega = angular.z;
+
+  double r_omega = (vel + omega * wheel_dist / 2) / wheel_radius;
+  double l_omega = (vel - omega * wheel_dist / 2) / wheel_radius;
+  odrive->setVelocity(0, l_omega);
+  odrive->setVelocity(1, r_omega);
 }
 
 void ODriveNode::odrive_callback()

--- a/odrive_node/src/odrive_node.cpp
+++ b/odrive_node/src/odrive_node.cpp
@@ -12,8 +12,7 @@ ODriveNode::ODriveNode() : Node("odrive_node")
   this->declare_parameter<int>("priority_bus_voltage", 2);
   this->declare_parameter<int>("priority_temperature", 3);
   this->declare_parameter<int>("priority_torque", 4);
-  this->declare_parameter<double>("wheel_dist", 3.14);
-  this->declare_parameter<double>("wheel_radius", 1);
+  this->declare_parameter<double>("wheel_dist",1);
 
   // node sets parameter, if given
   this->get_parameter("port", port);
@@ -23,7 +22,6 @@ ODriveNode::ODriveNode() : Node("odrive_node")
   this->get_parameter("priority_temperature", priority_temperature);
   this->get_parameter("priority_torque", priority_torque);
   this->get_parameter("wheel_dist", wheel_dist);
-  this->get_parameter("wheel_radius", wheel_radius);
 
   odrive = new ODrive(port, this);
 
@@ -113,10 +111,10 @@ void ODriveNode::cmd_velocity_callback(const geometry_msgs::msg::Twist::SharedPt
   Vector3 angular = msg->angular;
   Vector3 linear = msg->linear;
   double vel = linear.x;
-  double omega = angular.z;
+  double angle = angular.z;
 
-  double r_omega = (vel + omega * wheel_dist / 2) / wheel_radius;
-  double l_omega = (vel - omega * wheel_dist / 2) / wheel_radius;
+  double r_speed = (angle * wheel_dist) / 2 + vel;
+  double l_speed = vel * 2.0 - r_speed;
   odrive->setVelocity(0, l_omega);
   odrive->setVelocity(1, r_omega);
 }

--- a/odrive_node/src/odrive_node.hpp
+++ b/odrive_node/src/odrive_node.hpp
@@ -52,7 +52,6 @@ private:
     int priority_torque;
     int counter;
     int motor;
-    double wheel_radius;
     double wheel_dist;
     int order[4] = {0, 0, 0, 0};
     rclcpp::TimerBase::SharedPtr timer_;

--- a/odrive_node/src/odrive_node.hpp
+++ b/odrive_node/src/odrive_node.hpp
@@ -32,9 +32,12 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <string>
 #include "rclcpp/rclcpp.hpp"
 #include "std_msgs/msg/float32.hpp"
+#include "geometry_msgs/msg/twist.hpp"
+#include "geometry_msgs/msg/vector3.hpp"
 #include "ODrive.cpp"
 
 using namespace std::chrono_literals;
+
 class ODriveNode : public rclcpp::Node
 {
 public:
@@ -49,6 +52,8 @@ private:
     int priority_torque;
     int counter;
     int motor;
+    double wheel_radius;
+    double wheel_dist;
     int order[4] = {0, 0, 0, 0};
     rclcpp::TimerBase::SharedPtr timer_;
     rclcpp::Publisher<std_msgs::msg::Float32>::SharedPtr publisher_velocity0;
@@ -62,7 +67,9 @@ private:
     rclcpp::Publisher<std_msgs::msg::Float32>::SharedPtr publisher_temperature1;
     rclcpp::Subscription<std_msgs::msg::Float32>::SharedPtr subscription_velocity0;
     rclcpp::Subscription<std_msgs::msg::Float32>::SharedPtr subscription_velocity1;
+    rclcpp::Subscription<geometry_msgs::msg::Twist>::SharedPtr subscription_cmd_vel;
     void odrive_callback();
     void velocity_callback0(const std_msgs::msg::Float32::SharedPtr msg);
     void velocity_callback1(const std_msgs::msg::Float32::SharedPtr msg);
+    void cmd_velocity_callback(const geometry_msgs::msg::Twist::SharedPtr msg);
 };


### PR DESCRIPTION
This allows Twist messages to be consumed to power both motors. I believe address the issue with #2 